### PR TITLE
fix: Ollama batch runner restarts server between models

### DIFF
--- a/scripts/run_experiments.py
+++ b/scripts/run_experiments.py
@@ -5,6 +5,7 @@ Usage:
     python run_experiments.py --benchmarks cv-screening,stereoset --max-samples 10 --timeout 600
 """
 import argparse
+import atexit
 import json
 import logging
 import os
@@ -35,17 +36,28 @@ SLM_MODELS = [
 ]
 
 
+_ollama_server = None
+
+
 def _ensure_ollama():
-    """Check if Ollama is responding; restart if not."""
+    """Check if Ollama is responding; restart if not (singleton)."""
+    global _ollama_server
     try:
         subprocess.run(
             ["ollama", "list"], capture_output=True, check=True, timeout=10
         )
     except Exception:
+        # Stop old server and unregister its atexit handler
+        if _ollama_server is not None:
+            atexit.unregister(_ollama_server.stop)
+            try:
+                _ollama_server.stop()
+            except Exception:
+                pass
         logger.warning("Ollama not responding, restarting...")
         from llm_bias_testing.ollama_setup import OllamaServer
-        server = OllamaServer(kill_existing=True)
-        server.start()
+        _ollama_server = OllamaServer(kill_existing=True)
+        _ollama_server.start()
         logger.info("Ollama restarted")
 
 
@@ -59,8 +71,7 @@ def run_benchmarks(models, benchmarks, output_dir, max_samples, timeout):
             continue
 
         # Ensure Ollama is alive before each model (restart if crashed)
-        _ensure_ollama()
-        
+
         for benchmark in benchmarks:
             logger.info("=" * 60)
             logger.info("Running %s / %s", model_name, benchmark)
@@ -74,7 +85,10 @@ def run_benchmarks(models, benchmarks, output_dir, max_samples, timeout):
                     summary = json.load(f)
                 results_summary.append(summary)
                 continue
-            
+
+            # Ensure Ollama is alive before running the benchmark
+            _ensure_ollama()
+
             cmd = [
                 sys.executable, "-m", "llm_bias_testing.runner",
                 model_name,

--- a/scripts/run_experiments.py
+++ b/scripts/run_experiments.py
@@ -35,21 +35,31 @@ SLM_MODELS = [
 ]
 
 
+def _ensure_ollama():
+    """Check if Ollama is responding; restart if not."""
+    try:
+        subprocess.run(
+            ["ollama", "list"], capture_output=True, check=True, timeout=10
+        )
+    except Exception:
+        logger.warning("Ollama not responding, restarting...")
+        from llm_bias_testing.ollama_setup import OllamaServer
+        server = OllamaServer(kill_existing=True)
+        server.start()
+        logger.info("Ollama restarted")
+
+
 def run_benchmarks(models, benchmarks, output_dir, max_samples, timeout):
     """Run benchmarks across models sequentially."""
     results_summary = []
-    
+
     for model_name in models:
         if model_name not in MODELS:
             logger.warning("Unknown model: %s, skipping", model_name)
             continue
-        
-        # Check if ollama is running
-        try:
-            subprocess.run(["ollama", "list"], capture_output=True, check=True, timeout=10)
-        except Exception:
-            logger.error("Ollama server not available, skipping %s", model_name)
-            continue
+
+        # Ensure Ollama is alive before each model (restart if crashed)
+        _ensure_ollama()
         
         for benchmark in benchmarks:
             logger.info("=" * 60)
@@ -91,8 +101,8 @@ def run_benchmarks(models, benchmarks, output_dir, max_samples, timeout):
             except subprocess.TimeoutExpired:
                 logger.error("Timed out after %ds", timeout)
             
-            # Small delay between runs
-            time.sleep(2)
+            # Delay between runs to let Ollama stabilise
+            time.sleep(5)
     
     return results_summary
 


### PR DESCRIPTION
fix: Ollama batch runner restarts server between models

Problem: Running 11 models in a batch only completed 1 before Ollama crashed. The runner silently skipped the remaining 10 with server not available.

Fix: Added _ensure_ollama() that checks if Ollama is responding before each model and restarts via OllamaServer if dead. Increased inter-model delay from 2s to 5s for stabilisation. No more silent skips.

Testing: Syntax verified with ast.parse. Will validate with a real batch run after merge.