### PR TITLE
feat: num_ctx/keep_alive for Ollama 0.19+ MLX cache

### DIFF
--- a/scripts/phase1_run.sh
+++ b/scripts/phase1_run.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Phase 1: Run stereoset + demographic-bias for all 11 models sequentially
+# Kill-safe: skips already-completed pairs
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+LOG="results/phase1.log"
+mkdir -p results
+
+echo "=== Phase 1 start: $(date) ===" | tee "$LOG"
+
+models=(
+    "smollm-135m"
+    "smollm2-135m"
+    "smollm-360m"
+    "smollm2-360m"
+    "gemma3-270m"
+    "qwen25-05b"
+    "qwen3-06b"
+    "qwen35-08b"
+    "lfm2-350m"
+    "lfm2-700m"
+    "granite4-350m"
+)
+benchmarks=("stereoset" "demographic-bias")
+
+for model in "${models[@]}"; do
+    for bench in "${benchmarks[@]}"; do
+        outfile="results/$model/$bench/results.json"
+        if [ -f "$outfile" ]; then
+            echo "SKIP $model/$bench (exists)" | tee -a "$LOG"
+            continue
+        fi
+        echo "RUN $model/$bench at $(date)" | tee -a "$LOG"
+        if uv run python -m slm_bias_testing.runner "$model" --benchmark "$bench" --output-dir results --timeout 3600 2>&1 | tee -a "$LOG"; then
+            echo "DONE $model/$bench at $(date)" | tee -a "$LOG"
+        else
+            echo "FAIL $model/$bench at $(date) — continuing" | tee -a "$LOG"
+        fi
+        # Let Ollama stabilise between runs
+        sleep 10
+    done
+done
+
+echo "=== Phase 1 complete: $(date) ===" | tee -a "$LOG"
+echo "Results:" | tee -a "$LOG"
+find results -name "results.json" | sort | tee -a "$LOG"

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Run all benchmarks for all models. Kill-safe: skips completed pairs."""
+import json
+import logging
+import os
+import sys
+import time
+from datetime import datetime
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s",
+                    handlers=[logging.FileHandler("results/full_run.log", mode='a'),
+                              logging.StreamHandler()])
+log = logging.getLogger(__name__)
+
+RESULTS = os.path.expanduser("~/repos/slm-bias-testing/results")
+os.chdir(os.path.expanduser("~/repos/slm-bias-testing"))
+
+MODELS = [
+    "smollm-135m", "smollm2-135m", "smollm-360m", "smollm2-360m",
+    "gemma3-270m", "qwen25-05b", "qwen3-06b", "qwen35-08b",
+    "lfm2-350m", "lfm2-700m", "granite4-350m",
+]
+
+# All 4 benchmarks
+ALL_BENCHMARKS = ["stereoset", "demographic-bias", "winobias", "cv-screening"]
+
+def run_one(model, benchmark):
+    outfile = f"{RESULTS}/{model}/{benchmark}/results.json"
+    if os.path.exists(outfile):
+        log.info("SKIP %s/%s (exists)", model, benchmark)
+        return True
+    log.info("RUN %s/%s at %s", model, benchmark, datetime.now())
+    from slm_bias_testing.runner import run_benchmark_for_model
+    try:
+        run_benchmark_for_model(model, benchmark, RESULTS, 7200)  # 2h timeout
+        ok = os.path.exists(outfile)
+        if ok:
+            log.info("DONE %s/%s at %s", model, benchmark, datetime.now())
+        else:
+            log.error("FAIL %s/%s — no results.json after run", model, benchmark)
+        return ok
+    except Exception as e:
+        log.exception("FAIL %s/%s: %s", model, benchmark, e)
+        return False
+
+def main():
+    which = sys.argv[1] if len(sys.argv) > 1 else "all"
+    
+    # Parse --num-ctx from argv if present
+    num_ctx = None
+    for i, arg in enumerate(sys.argv):
+        if arg == "--num-ctx" and i + 1 < len(sys.argv):
+            num_ctx = int(sys.argv[i + 1])
+            os.environ["SLM_NUM_CTX"] = str(num_ctx)
+
+    if num_ctx is not None:
+        log.info("Using num_ctx=%d (Ollama 0.19+ MLX cache optimisation)", num_ctx)
+    
+    if which == "all":
+        benchmarks = ALL_BENCHMARKS
+    elif which == "phase1":
+        benchmarks = ["stereoset", "demographic-bias"]
+    elif which == "phase2":
+        benchmarks = ["winobias"]
+    elif which == "phase3":
+        benchmarks = ["cv-screening"]
+    else:
+        benchmarks = [which]
+    
+    log.info("=== Run %s at %s ===", which, datetime.now())
+    log.info("Models: %d, Benchmarks: %s", len(MODELS), benchmarks)
+    
+    done = failed = skipped = 0
+    total = len(MODELS) * len(benchmarks)
+    
+    for model in MODELS:
+        for benchmark in benchmarks:
+            outfile = f"{RESULTS}/{model}/{benchmark}/results.json"
+            if os.path.exists(outfile):
+                skipped += 1
+                continue
+            
+            if run_one(model, benchmark):
+                done += 1
+            else:
+                failed += 1
+            time.sleep(5)
+    
+    log.info("=== Complete: %d done, %d failed, %d skipped of %d ===", done, failed, skipped, total)
+    
+    # Summary
+    log.info("=== Results summary ===")
+    for model in MODELS:
+        for benchmark in benchmarks:
+            outfile = f"{RESULTS}/{model}/{benchmark}/results.json"
+            if os.path.exists(outfile):
+                with open(outfile) as f:
+                    data = json.load(f)
+                n = data.get("n_records") or data.get("n_examples") or 0
+                score = data.get("overall_stereotype_score") or data.get("bias_score") or data.get("mean_score") or "-"
+                log.info("  %s/%s: n=%d, score=%s", model, benchmark, n, score)
+
+if __name__ == "__main__":
+    main()

--- a/src/slm_bias_testing/call_api.py
+++ b/src/slm_bias_testing/call_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import os
 import time
 from typing import TYPE_CHECKING
 
@@ -18,6 +19,15 @@ logger = logging.getLogger(__name__)
 
 LLM_MODEL = "gemma3:1b-it-qat"
 PROVIDER = "ollama"
+
+# Default context window. Ollama 0.19+ uses MLX on Apple Silicon with intelligent
+# KV cache checkpoints — setting an explicit num_ctx lets Ollama optimise cache
+# allocation.  See: https://ollama.com/blog/mlx
+DEFAULT_NUM_CTX = int(os.environ.get("SLM_NUM_CTX", "2048"))
+
+# How long to keep the model loaded after last API call (seconds).
+# Longer values reduce model reload overhead across sequential benchmark items.
+DEFAULT_KEEP_ALIVE = float(os.environ.get("SLM_KEEP_ALIVE", "5"))
 
 
 class OllamaClient:
@@ -54,9 +64,13 @@ class Model:
         model_name: str = LLM_MODEL,
         provider: str = PROVIDER,
         ollama_client: OllamaClient | None = None,
+        num_ctx: int | None = None,
+        keep_alive: float | None = None,
     ) -> None:
         self.model_name = model_name
         self.provider = provider
+        self.num_ctx = num_ctx if num_ctx is not None else DEFAULT_NUM_CTX
+        self.keep_alive = keep_alive if keep_alive is not None else DEFAULT_KEEP_ALIVE
         self._ollama_client = ollama_client or OllamaClient()
         self._transformer_model: TransformerModel | None = None
 
@@ -82,7 +96,11 @@ class Model:
                 response = self._ollama_client.client.chat(
                     model=self.model_name,
                     messages=[{"role": "user", "content": input_text}],
-                    options={"temperature": temperature},
+                    options={
+                        "temperature": temperature,
+                        "num_ctx": self.num_ctx,
+                    },
+                    keep_alive=self.keep_alive,
                 )
                 return response["message"]["content"]  # type: ignore[no-any-return]
             except Exception as e:
@@ -93,7 +111,9 @@ class Model:
                     e,
                 )
                 if attempt < max_retries - 1:
-                    self._ollama_client.ensure_running()
+                    # Only restart on actual connection failure, not on every error
+                    if "connect" in str(e).lower() or "refused" in str(e).lower():
+                        self._ollama_client.ensure_running()
                     time.sleep(2)
                 else:
                     raise

--- a/src/slm_bias_testing/runner.py
+++ b/src/slm_bias_testing/runner.py
@@ -88,9 +88,10 @@ def run_benchmark_for_model(
                 "std_score": float(df["score"].std()) if df is not None and not df.empty else None,
             }
         else:
+            from slm_bias_testing.call_api import DEFAULT_NUM_CTX
             from slm_bias_testing.call_api import Model as ApiModel
 
-            model = ApiModel(model_name=ollama_tag)
+            model = ApiModel(model_name=ollama_tag, num_ctx=DEFAULT_NUM_CTX)
 
             if bench == "stereoset":
                 from slm_bias_testing.benchmarks.stereoset import StereoSetBenchmark

--- a/tests/test_call_api.py
+++ b/tests/test_call_api.py
@@ -6,7 +6,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from slm_bias_testing.call_api import LLM_MODEL, PROVIDER, Model, OllamaClient
+from slm_bias_testing.call_api import (
+    DEFAULT_KEEP_ALIVE,
+    DEFAULT_NUM_CTX,
+    LLM_MODEL,
+    PROVIDER,
+    Model,
+    OllamaClient,
+)
 
 
 class TestOllamaClient:
@@ -36,11 +43,15 @@ class TestModelInit:
             model = Model()
         assert model.model_name == LLM_MODEL
         assert model.provider == PROVIDER
+        assert model.num_ctx == DEFAULT_NUM_CTX
+        assert model.keep_alive == DEFAULT_KEEP_ALIVE
 
     def test_model_init_custom(self):
-        model = Model(model_name="custom-model", provider="custom")
+        model = Model(model_name="custom-model", provider="custom", num_ctx=4096, keep_alive=10.0)
         assert model.model_name == "custom-model"
         assert model.provider == "custom"
+        assert model.num_ctx == 4096
+        assert model.keep_alive == 10.0
 
     def test_model_init_with_custom_client(self):
         mock_client = MagicMock(spec=OllamaClient)
@@ -61,9 +72,13 @@ class TestModelPredict:
         mock_client.ensure_running = MagicMock()
         mock_client.client = MagicMock()
         mock_client.client.chat.return_value = {"message": {"content": "42/100"}}
-
         model = Model(model_name="test", provider="ollama", ollama_client=mock_client)
         result = model.predict("score this", temperature=0.5)
+        assert result == "42/100"
+        # Verify num_ctx and keep_alive are passed through
+        call_kwargs = mock_client.client.chat.call_args
+        assert call_kwargs.kwargs["options"]["num_ctx"] == DEFAULT_NUM_CTX
+        assert call_kwargs.kwargs["keep_alive"] == DEFAULT_KEEP_ALIVE
         assert result == "42/100"
 
     def test_predict_ollama_retries_on_failure(self):
@@ -71,13 +86,15 @@ class TestModelPredict:
         mock_client.ensure_running = MagicMock()
         mock_client.client = MagicMock()
         mock_client.client.chat.side_effect = [
-            ConnectionError("timeout"),
+            ConnectionError("connection refused"),
             {"message": {"content": "ok"}},
         ]
-
         model = Model(model_name="test", provider="ollama", ollama_client=mock_client)
         result = model.predict("hello")
         assert result == "ok"
+        assert mock_client.client.chat.call_count == 2
+        # Connection error should trigger ensure_running restart
+        assert mock_client.ensure_running.call_count >= 1
         assert mock_client.client.chat.call_count == 2
 
     def test_predict_transformers(self):


### PR DESCRIPTION
## Summary
Ollama 0.19+ uses MLX on Apple Silicon with intelligent KV cache checkpoints (https://ollama.com/blog/mlx). This PR sets explicit num_ctx and keep_alive parameters so our benchmark harness benefits from Ollama's improved caching.

## Changes
- call_api.py: Add num_ctx (default 2048) and keep_alive (default 5s) to Model, passed through to Ollama chat API options
- call_api.py: Only restart Ollama on connection errors (not every API failure — reduces restart churn)
- runner.py: Pass DEFAULT_NUM_CTX to Model constructor
- run_all.py: Add --num-ctx CLI option + SLM_NUM_CTX env var support
- tests: Cover new parameters and connection-error-only restart logic

## Config
- SLM_NUM_CTX env var or --num-ctx CLI flag (default: 2048)
- SLM_KEEP_ALIVE env var (default: 5s)
