### PR TITLE
chore(opencode): switch default model to big-pickle

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "opencode-go/mimo-v2.5",
+  "model": "opencode/big-pickle",
   "instructions": ["AGENTS.md"],
   "skills": {
     "paths": [".opencode/skills"]


### PR DESCRIPTION
Switches the opencode default model from `opencode-go/mimo-v2.5` to `opencode/big-pickle`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration settings to use a new model version. This update may improve performance and stability of background operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->